### PR TITLE
Update docusaurus.config.js copyright to match LICENSE.md

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -41,7 +41,7 @@ module.exports = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} Seneca College.`,
+      copyright: `Copyright © ${new Date().getFullYear()} Chris Szalwinski and Seneca College.`,
     },
     prism: {
       theme: lightCodeTheme,


### PR DESCRIPTION
Follow-up to fix in https://github.com/Seneca-ICTOER/Intro2C/pull/180, since this needs it too.